### PR TITLE
Refactored cortex wrapper to not extend Promise for ES6 compatibility

### DIFF
--- a/nodejs/lib/cortex.js
+++ b/nodejs/lib/cortex.js
@@ -6,11 +6,8 @@
  * We use it both in the browser and NodeJS code.
  *
  * It makes extensive use of Promises for flow control; all requests return a
- * Promise with their result. To make it easier to chain together sequences of
- * operations, we use a special Promise subclass that lets us do things like
- * client.auth().createSession().subscribe() while still maintaining sensible
- * control flow and error handling.
- *
+ * Promise with their result. 
+ * 
  * For the subscription types in Cortex, we use an event emitter. Each kind of
  * event (mot, eeg, etc) is emitted as its own event that you can listen for
  * whether or not there are any active subscriptions at the time.
@@ -20,183 +17,177 @@
  * exception of the login/auth flow, which we expose as the init() method.
  */
 
-const WebSocket = require('ws')
-const EventEmitter = require('events')
+const WebSocket = require("ws");
+const EventEmitter = require("events");
 
-const CORTEX_URL = 'wss://emotivcortex.com:54321'
+const CORTEX_URL = "wss://emotivcortex.com:54321";
 
-const safeParse = (msg) => { try { return JSON.parse(msg) } catch (_) { return null } }
-
-const makeChainablePromise = (parent) => {
-  class ChainablePromise extends Promise {
-    static proxy (method) {
-      if (this.prototype[method]) return
-
-      this.prototype[method] = function (...args) {
-        return this.then(() => parent[method](...args))
-      }
-    }
+const safeParse = msg => {
+  try {
+    return JSON.parse(msg);
+  } catch (_) {
+    return null;
   }
-  const proto = parent.constructor ? parent.constructor.prototype : {}
-  for (const method of Object.getOwnPropertyNames(proto)) {
-    if (typeof parent[method] === 'function' &&
-        method[0] !== '_' &&
-        method !== 'constructor') {
-      ChainablePromise.proxy(method)
-    }
-  }
-  return ChainablePromise
-}
+};
 
 if (global.process) {
-  process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
+  process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
 }
 
 class JSONRPCError extends Error {
-  constructor (err) {
-    super(err.message)
-    this.name = this.constructor.name
-    this.message = err.message
-    this.code = err.code
+  constructor(err) {
+    super(err.message);
+    this.name = this.constructor.name;
+    this.message = err.message;
+    this.code = err.code;
   }
-  toString () {
-    return super.toString() + ` (${this.code})`
+  toString() {
+    return `${super.toString()} (${this.code})`;
   }
 }
 
 class Cortex extends EventEmitter {
-  constructor (options = {}) {
-    super()
-    this.options = options
-    this.ws = new WebSocket(CORTEX_URL)
-    this.msgId = 0
-    this.requests = {}
-    this.streams = {}
-    this.ws.addEventListener('message', this._onmsg.bind(this))
-    this.ws.addEventListener('close', () => {
-      this._log('ws: Socket closed')
-      this.call = () => this.APIResult.reject(new Error('socket closed'))
-    })
-    this.verbose = options.verbose !== null ? options.verbose : 1
-    this.APIResult = makeChainablePromise(this)
+  constructor(options = {}) {
+    super();
+    this.options = options;
+    this.ws = new WebSocket(CORTEX_URL);
+    this.msgId = 0;
+    this.requests = {};
+    this.streams = {};
+    this.ws.addEventListener("message", this._onmsg.bind(this));
+    this.ws.addEventListener("close", () => {
+      this._log("ws: Socket closed");
+    });
+    this.verbose = options.verbose !== null ? options.verbose : 1;
+    this.handleError = error => {
+      throw new JSONRPCError(error);
+    };
 
-    this.ready =
-      new this.APIResult(resolve => this.ws.addEventListener('open', resolve))
-        .then(() => this._log('ws: Socket opened'))
-        .call('inspectApi')
-        .then(methods => {
-          for (const m of methods) this.defineMethod(m.methodName, m.params)
-          this._log(`rpc: Added ${methods.length} methods from inspectApi`)
-        })
+    this.ready = new Promise(
+      resolve => this.ws.addEventListener("open", resolve),
+      this.handleError
+    )
+      .then(() => this._log("ws: Socket opened"))
+      .then(() => this.call("inspectApi"))
+      .then(methods => {
+        for (const m of methods) this.defineMethod(m.methodName, m.params);
+        this._log(`rpc: Added ${methods.length} methods from inspectApi`);
+      });
   }
-  _onmsg (msg) {
-    const data = safeParse(msg.data)
-    if (!data) return this._warn('unparseable message', msg)
+  _onmsg(msg) {
+    const data = safeParse(msg.data);
+    if (!data) return this._warn("unparseable message", msg);
 
-    this._debug('ws: <-', msg.data)
+    this._debug("ws: <-", msg.data);
 
-    if ('id' in data) {
-      const id = data.id
-      this._log(`[${id}] <-`, data.result ? 'success' : `error (${data.error.message})`)
+    if ("id" in data) {
+      const id = data.id;
+      this._log(
+        `[${id}] <-`,
+        data.result ? "success" : `error (${data.error.message})`
+      );
       if (this.requests[id]) {
-        this.requests[id](data.error, data.result)
+        this.requests[id](data.error, data.result);
       } else {
-        this._warn('rpc: Got response for unknown id', id)
+        this._warn("rpc: Got response for unknown id", id);
       }
-    } else if ('sid' in data) {
-      const dataKeys = Object.keys(data).filter(k =>
-        k !== 'sid' && k !== 'time' && Array.isArray(data[k])
-      )
+    } else if ("sid" in data) {
+      const dataKeys = Object.keys(data).filter(
+        k => k !== "sid" && k !== "time" && Array.isArray(data[k])
+      );
       for (const k of dataKeys) {
-        this.emit(k, data) || this._warn('no listeners for stream event', k)
+        this.emit(k, data) || this._warn("no listeners for stream event", k);
       }
     } else {
-      this._log('rpc: Unrecognised data', data)
+      this._log("rpc: Unrecognised data", data);
     }
   }
-  _warn (...msg) {
-    if (this.verbose > 0) console.warn('[Cortex WARN]', ...msg)
+  _warn(...msg) {
+    if (this.verbose > 0) console.warn("[Cortex WARN]", ...msg);
   }
-  _log (...msg) {
-    if (this.verbose > 1) console.warn('[Cortex LOG]', ...msg)
+  _log(...msg) {
+    if (this.verbose > 1) console.warn("[Cortex LOG]", ...msg);
   }
-  _debug (...msg) {
-    if (this.verbose > 2) console.warn('[Cortex DEBUG]', ...msg)
+  _debug(...msg) {
+    if (this.verbose > 2) console.warn("[Cortex DEBUG]", ...msg);
   }
-  init ({username, password, client_id, client_secret, debit} = {}) {
+  init({ username, password, client_id, client_secret, debit } = {}) {
     const result = this.getUserLogin()
       .then(users => {
         if (users[0] && users[0] !== username) {
-          this._log('init: Logging out other user', users[0])
-          return this.logout({username: users[0]}).then(() => [])
+          this._log("init: Logging out other user", users[0]);
+          return this.logout({ username: users[0] }).then(() => []);
         }
         if (username) {
-          this._log('init: Reusing existing login')
+          this._log("init: Reusing existing login");
         } else {
-          this._log('init: Logging in anonymously')
+          this._log("init: Logging in anonymously");
         }
-        return users
+        return users;
       })
       .then(users => {
         if (!users[0] && username && password) {
-          this._log('init: Logging in as', username)
-          return this.login({username, password, client_id, client_secret})
+          this._log("init: Logging in as", username);
+          return this.login({ username, password, client_id, client_secret });
         }
       })
-      .authorize({client_id, client_secret, debit}).then(({_auth}) => {
-        this._log('init: Got auth token')
-        this._debug('init: Auth token', _auth)
-        this._auth = _auth
-      })
+      .then(() => this.authorize({ client_id, client_secret, debit }))
+      .then(({ _auth }) => {
+        this._log("init: Got auth token");
+        this._debug("init: Auth token", _auth);
+        this._auth = _auth;
+      });
 
-    return result
+    return result;
   }
-  close () {
-    return new this.APIResult((resolve) => {
-      this.ws.close()
-      this.ws.once('close', resolve)
-    })
+  close() {
+    return new Promise(resolve => {
+      this.ws.close();
+      this.ws.once("close", resolve);
+    });
   }
-  call (method, params = {}) {
-    const id = this.msgId++
-    const msg = JSON.stringify({jsonrpc: '2.0', method, params, id})
-    this.ws.send(msg)
-    this._log(`[${id}] -> ${method}`)
+  call(method, params = {}) {
+    const id = this.msgId++;
+    const msg = JSON.stringify({ jsonrpc: "2.0", method, params, id });
+    this.ws.send(msg);
+    this._log(`[${id}] -> ${method}`);
 
-    this._debug('ws: ->', msg)
-    return new this.APIResult((resolve, reject) => {
+    this._debug("ws: ->", msg);
+    return new Promise((resolve, reject) => {
       this.requests[id] = (err, data) => {
-        delete this.requests[id]
-        this._debug('rpc: err', err, 'data', data)
-        if (err) return reject(new JSONRPCError(err))
-        if (data) return resolve(data)
-        return reject(new Error('Invalid JSON-RPC response'))
-      }
-    })
+        delete this.requests[id];
+        this._debug("rpc: err", err, "data", data);
+        if (err) return reject(new JSONRPCError(err));
+        if (data) return resolve(data);
+        return reject(new Error("Invalid JSON-RPC response"));
+      };
+    });
   }
-  defineMethod (methodName, paramDefs = []) {
-    if (this[methodName]) return
-    const needsAuth = paramDefs.some(p => p.name === '_auth')
-    const requiredParams = paramDefs.filter(p => p.required).map(p => p.name)
+  defineMethod(methodName, paramDefs = []) {
+    if (this[methodName]) return;
+    const needsAuth = paramDefs.some(p => p.name === "_auth");
+    console.log("method: ", methodName, " needs auth: ", needsAuth);
+    const requiredParams = paramDefs.filter(p => p.required).map(p => p.name);
 
     this[methodName] = (params = {}) => {
       if (needsAuth && this._auth && !params._auth) {
-        params = Object.assign({}, params, {_auth: this._auth})
+        params = Object.assign({}, params, { _auth: this._auth });
       }
-      const missingParams = requiredParams.filter(p => params[p] == null)
+      const missingParams = requiredParams.filter(p => params[p] == null);
       if (missingParams.length > 0) {
-        return this.APIResult.reject(
-          new Error(`Missing required params for ${methodName}: ${missingParams.join(', ')}`)
-        )
+        return this.handleError(
+          new Error(
+            `Missing required params for ${methodName}: ${missingParams.join(
+              ", "
+            )}`
+          )
+        );
       }
-      return this.call(methodName, params)
-    }
-
-    this.APIResult.proxy(methodName)
+      return this.call(methodName, params);
+    };
   }
 }
 
-Cortex.JSONRPCError = JSONRPCError
-Cortex.makeChainablePromise = makeChainablePromise
+Cortex.JSONRPCError = JSONRPCError;
 
-module.exports = Cortex
+module.exports = Cortex;

--- a/nodejs/src/events.js
+++ b/nodejs/src/events.js
@@ -20,104 +20,113 @@
  *
  */
 
-const Cortex = require('../lib/cortex')
+const Cortex = require("../lib/cortex");
 
 // Small wrapper function  to turn the column-oriented format we get from the
 // API into key:value pairs
-const columns2obj = (headers) => (cols) => {
-  const obj = {}
+const columns2obj = headers => cols => {
+  const obj = {};
   for (let i = 0; i < cols.length; i++) {
-    obj[headers[i]] = cols[i]
+    obj[headers[i]] = cols[i];
   }
-  return obj
-}
+  return obj;
+};
 
-function events (client, threshold, onResult) {
+function events(client, threshold, onResult) {
   return client
-    .createSession({status: 'open'})
-    .subscribe({streams: ['com', 'fac']})
+    .createSession({ status: "open" })
+    .then(() => client.subscribe({ streams: ["com", "fac"] }))
     .then(subs => {
-      if (!subs[0].com || !subs[1].fac) throw new Error('failed to subscribe')
+      if (!subs[0].com || !subs[1].fac) throw new Error("failed to subscribe");
 
       const current = {
-        command: 'neutral',
-        eyes: 'neutral',
-        brows: 'neutral',
-        mouth: 'neutral'
-      }
+        command: "neutral",
+        eyes: "neutral",
+        brows: "neutral",
+        mouth: "neutral"
+      };
 
       // Here we listen for facial expressions
-      const fac2obj = columns2obj(subs[1].fac.cols)
-      const onFac = (ev) => {
-        const data = fac2obj(ev.fac)
+      const fac2obj = columns2obj(subs[1].fac.cols);
+      const onFac = ev => {
+        const data = fac2obj(ev.fac);
 
-        let updated = false
+        let updated = false;
         let update = (k, v) => {
           if (current[k] !== v) {
-            updated = true
-            current[k] = v
+            updated = true;
+            current[k] = v;
           }
-        }
+        };
 
         // Eye direction doesn't have a power rating, so we send every change
-        update('eyes', data.eyeAct)
-        if (data.uPow >= threshold) update('brows', data.uAct)
-        if (data.lPow >= threshold) update('mouth', data.lAct)
+        update("eyes", data.eyeAct);
+        if (data.uPow >= threshold) update("brows", data.uAct);
+        if (data.lPow >= threshold) update("mouth", data.lAct);
 
-        if (updated) onResult(Object.assign({}, current))
-      }
-      client.on('fac', onFac)
+        if (updated) onResult(Object.assign({}, current));
+      };
+      client.on("fac", onFac);
 
       // And here we do mental commands
-      const com2obj = columns2obj(subs[0].com.cols)
-      const onCom = (ev) => {
-        const data = com2obj(ev.com)
+      const com2obj = columns2obj(subs[0].com.cols);
+      const onCom = ev => {
+        const data = com2obj(ev.com);
         if (data.act !== current.command && data.pow >= threshold) {
-          current.command = data.act
-          onResult(Object.assign({}, current))
+          current.command = data.act;
+          onResult(Object.assign({}, current));
         }
-      }
-      client.on('com', onCom)
+      };
+      client.on("com", onCom);
 
       // Return a function to call to finish up
       return () =>
         client
-          .unsubscribe({streams: ['com', 'fac']})
-          .updateSession({status: 'close'})
+          .unsubscribe({ streams: ["com", "fac"] })
+          .then(() => client.updateSession({ status: "close" }))
           .then(() => {
-            client.removeListener('com', onCom)
-            client.removeListener('fac', onFac)
-          })
-    })
+            client.removeListener("com", onCom);
+            client.removeListener("fac", onFac);
+          });
+    });
 }
 
 const pad = (str, n) =>
-  str + new Array(Math.max(0, n - str.length + 1)).join(' ')
+  str + new Array(Math.max(0, n - str.length + 1)).join(" ");
 
 // This is the main module that gets evaluated when you run it from the
 // command line
 if (require.main === module) {
-  process.on('unhandledRejection', (err) => { throw err })
+  process.on("unhandledRejection", err => {
+    throw err;
+  });
 
   // We can set LOG_LEVEL=2 or 3 for more detailed errors
-  const verbose = process.env.LOG_LEVEL || 1
-  const options = {verbose, threshold: 0}
-  const threshold = 0
+  const verbose = process.env.LOG_LEVEL || 1;
+  const options = { verbose, threshold: 0 };
+  const threshold = 0;
 
-  const client = new Cortex(options)
+  const client = new Cortex(options);
 
-  client.ready
-    .then(() => client.init())
-    .then(() => {
-      console.log(`Watching for facial expressions and mental commands above ${Math.round(threshold * 100)}% power`)
+  client.ready.then(() => client.init()).then(() => {
+    console.log(
+      `Watching for facial expressions and mental commands above ${Math.round(
+        threshold * 100
+      )}% power`
+    );
 
-      events(client, threshold, ({eyes, brows, mouth, command}) => {
-        console.log(`eyes: ${pad(eyes, 10)} | brows: ${pad(brows, 10)} | mouth: ${pad(mouth, 10)} | command: ${command}`)
-      })
-    })
+    events(client, threshold, ({ eyes, brows, mouth, command }) => {
+      console.log(
+        `eyes: ${pad(eyes, 10)} | brows: ${pad(brows, 10)} | mouth: ${pad(
+          mouth,
+          10
+        )} | command: ${command}`
+      );
+    });
+  });
 
   // We could use the value returned by events() here, but when we ctrl+c it
   // will clean up the connection anyway
 }
 
-module.exports = events
+module.exports = events;

--- a/nodejs/src/numbers.js
+++ b/nodejs/src/numbers.js
@@ -14,30 +14,31 @@
  *
  */
 
-const Cortex = require('../lib/cortex')
+const Cortex = require("../lib/cortex");
 
-function rollingAverage (columns, windowSize) {
-  let avgCount = 0
-  const averages = {}
-  return (row) => {
-    avgCount = Math.min(windowSize, avgCount + 1)
+function rollingAverage(columns, windowSize) {
+  let avgCount = 0;
+  const averages = {};
+  return row => {
+    avgCount = Math.min(windowSize, avgCount + 1);
 
     columns.forEach((col, i) => {
-      const oldAvg = averages[col] || 0
-      averages[col] = oldAvg + (row[i] - oldAvg) / avgCount
-    })
+      const oldAvg = averages[col] || 0;
+      averages[col] = oldAvg + (row[i] - oldAvg) / avgCount;
+    });
 
-    return averages
-  }
+    return averages;
+  };
 }
 
-function numbers (client, windowSize, onResult) {
+function numbers(client, windowSize, onResult) {
   return client
-    .createSession({status: 'open'})
-    .subscribe({streams: ['pow', 'mot', 'met']})
+    .createSession({ status: "open" })
+    .then(() => client.subscribe({ streams: ["pow", "mot", "met"] }))
     .then(_subs => {
-      const subs = Object.assign({}, ..._subs)
-      if (!subs.pow || !subs.mot || !subs.met) throw new Error('failed to subscribe')
+      const subs = Object.assign({}, ..._subs);
+      if (!subs.pow || !subs.mot || !subs.met)
+        throw new Error("failed to subscribe");
 
       // Create a list of all the column indices relevant to each band
       // (there'll be one per sensor)
@@ -47,104 +48,104 @@ function numbers (client, windowSize, onResult) {
         betaL: [],
         betaH: [],
         gamma: []
-      }
+      };
       for (let i = 0; i < subs.pow.cols.length; i++) {
         // pow columns look like: IED_AF3/alpha
-        const bandName = subs.pow.cols[i].split('/')[1]
-        bands[bandName].push(i)
+        const bandName = subs.pow.cols[i].split("/")[1];
+        bands[bandName].push(i);
       }
-      const bandNames = Object.keys(bands)
+      const bandNames = Object.keys(bands);
 
       // Motion data columns look like 'IMD_GYROX', this will make them look like 'gyroX'
-      const makeFriendlyCol = (col) =>
-          col.replace(/^IMD_(.*?)([XYZ]?)$/, (_, name, dim) => name.toLowerCase() + dim)
+      const makeFriendlyCol = col =>
+        col.replace(
+          /^IMD_(.*?)([XYZ]?)$/,
+          (_, name, dim) => name.toLowerCase() + dim
+        );
 
-      const motCols = subs.mot.cols.map(makeFriendlyCol)
+      const motCols = subs.mot.cols.map(makeFriendlyCol);
 
       // Set up our rolling average functions
       // met always gets a window size of 1 because at the basic subscription
       // level it's averaged over 10s anyway
-      const averageMet = rollingAverage(subs.met.cols, 1)
-      const averageMot = rollingAverage(motCols, windowSize)
-      const averageBands = rollingAverage(bandNames, windowSize)
+      const averageMet = rollingAverage(subs.met.cols, 1);
+      const averageMot = rollingAverage(motCols, windowSize);
+      const averageBands = rollingAverage(bandNames, windowSize);
 
-      const data = {}
+      const data = {};
       for (const col of [...motCols, ...subs.met.cols, ...bandNames]) {
-        data[col] = 0
+        data[col] = 0;
       }
 
-      const onMet = (ev) =>
-        maybeUpdate('met', averageMet(ev.met))
-      client.on('met', onMet)
+      const onMet = ev => maybeUpdate("met", averageMet(ev.met));
+      client.on("met", onMet);
 
-      const onMot = (ev) =>
-        maybeUpdate('mot', averageMot(ev.mot))
-      client.on('mot', onMot)
+      const onMot = ev => maybeUpdate("mot", averageMot(ev.mot));
+      client.on("mot", onMot);
 
       // This averages overall the sensors in the pow stream to give us our
       // "bands" stream
-      const averageSensors = (pow) =>
-        bandNames.map((bandName) => {
-          const sum =
-            bands[bandName]
-              .map(i => pow[i])
-              .reduce((total, row) => total + row, 0)
-          return sum / bands[bandName].length
-        })
+      const averageSensors = pow =>
+        bandNames.map(bandName => {
+          const sum = bands[bandName]
+            .map(i => pow[i])
+            .reduce((total, row) => total + row, 0);
+          return sum / bands[bandName].length;
+        });
 
-      const onPow = (ev) =>
-        maybeUpdate('bands', averageBands(averageSensors(ev.pow)))
-      client.on('pow', onPow)
+      const onPow = ev =>
+        maybeUpdate("bands", averageBands(averageSensors(ev.pow)));
+      client.on("pow", onPow);
 
       // Choosing whether to update here is a bit tricky - we want to update
       // at the rate of the fastest stream, but we don't know which one that
       // will be. So we just wait until we get a second update for the same
       // stream to send everything - that stream must be the fastest.
-      let hasUpdate = {}
+      let hasUpdate = {};
       const maybeUpdate = (key, newdata) => {
         if (hasUpdate[key]) {
-          onResult(data)
-          hasUpdate = {}
+          onResult(data);
+          hasUpdate = {};
         }
-        hasUpdate[key] = true
-        Object.assign(data, newdata)
-      }
+        hasUpdate[key] = true;
+        Object.assign(data, newdata);
+      };
 
       return () =>
         client
-          .unsubscribe({streams: ['pow', 'mot', 'met']})
-          .updateSession({status: 'close'})
+          .unsubscribe({ streams: ["pow", "mot", "met"] })
+          .then(() => client.updateSession({ status: "close" }))
           .then(() => {
-            client.removeListener('mot', onMot)
-            client.removeListener('pow', onPow)
-          })
-    })
+            client.removeListener("mot", onMot);
+            client.removeListener("pow", onPow);
+          });
+    });
 }
 
 if (require.main === module) {
-  process.on('unhandledRejection', (err) => { throw err })
+  process.on("unhandledRejection", err => {
+    throw err;
+  });
 
   // We can set LOG_LEVEL=2 or 3 for more detailed errors
-  const verbose = process.env.LOG_LEVEL || 1
-  const options = {verbose}
-  const avgWindow = 10
+  const verbose = process.env.LOG_LEVEL || 1;
+  const options = { verbose };
+  const avgWindow = 10;
 
-  const client = new Cortex(options)
+  const client = new Cortex(options);
 
-  client.ready
-    .then(() => client.init())
-    .then(() =>
-      numbers(client, avgWindow, (averages) => {
-        const output = Object.keys(averages)
-          .map(k => `${k}: ${averages[k].toFixed(2)}`)
-          .join(', ')
+  client.ready.then(() => client.init()).then(() =>
+    numbers(client, avgWindow, averages => {
+      const output = Object.keys(averages)
+        .map(k => `${k}: ${averages[k].toFixed(2)}`)
+        .join(", ");
 
-        console.log(output)
-      })
-    )
+      console.log(output);
+    })
+  );
 
   // We could use the value returned by numbers) here, but when we ctrl+c it
   // will clean up the connection anyway
 }
 
-module.exports = numbers
+module.exports = numbers;

--- a/nodejs/src/raw.js
+++ b/nodejs/src/raw.js
@@ -9,90 +9,92 @@
  *
  */
 
-const Cortex = require('../lib/cortex')
+const Cortex = require("../lib/cortex");
 
-function raw (client, onResult) {
+function raw(client, onResult) {
   return client
-    .createSession({status: 'active'})
-    .subscribe({streams: ['eeg']})
+    .createSession({ status: "active" })
+    .then(() => client.subscribe({ streams: ["eeg"] }))
     .then(subs => {
-      if (!subs[0].eeg) throw new Error('failed to subscribe')
+      if (!subs[0].eeg) throw new Error("failed to subscribe");
 
-      const headers = subs[0].eeg.cols.slice()
-      headers.unshift('seq', 'time')
-      headers.headers = true
+      const headers = subs[0].eeg.cols.slice();
+      headers.unshift("seq", "time");
+      headers.headers = true;
 
-      let n = 0
-      const onEeg = (data) => {
-        if (n === 0) onResult(headers)
-        onResult([n, data.time].concat(data.eeg))
-        n++
-      }
+      let n = 0;
+      const onEeg = data => {
+        if (n === 0) onResult(headers);
+        onResult([n, data.time].concat(data.eeg));
+        n++;
+      };
 
-      client.on('eeg', onEeg)
+      client.on("eeg", onEeg);
 
       return () =>
         client
           .inspectApi()
-          .unsubscribe({streams: ['eeg']})
-          .updateSession({status: 'close'})
-          .then(() => client.removeListener('eeg', onEeg))
-    })
+          .then(() => client.unsubscribe({ streams: ["eeg"] }))
+          .then(() => client.updateSession({ status: "close" }))
+          .then(() => client.removeListener("eeg", onEeg));
+    });
 }
 
 if (require.main === module) {
-  process.on('unhandledRejection', (err) => { throw err })
+  process.on("unhandledRejection", err => {
+    throw err;
+  });
 
-  const readline = require('readline')
-  const stdin = process.stdin
-  readline.emitKeypressEvents(stdin)
-  if (stdin.isTTY) stdin.setRawMode(true)
+  const readline = require("readline");
+  const stdin = process.stdin;
+  readline.emitKeypressEvents(stdin);
+  if (stdin.isTTY) stdin.setRawMode(true);
 
-  const verbose = process.env.LOG_LEVEL || 1
-  const options = {verbose}
-
-  const client = new Cortex(options)
+  const verbose = process.env.LOG_LEVEL || 1;
+  const options = { verbose };
+  const client = new Cortex(options);
   // these values need to fill to run example
   const auth = {
-    username: '...',
-    password: '...',
-    client_id: '...',
-    client_secret: '...',
+    username: "...",
+    password: "...",
+    client_id: "...",
+    client_secret: "...",
     debit: 1 // first time you run example debit should > 0
-  }
+  };
 
   client.ready
     .then(() => client.init(auth))
-    .then(() =>
-      raw(client, (rawData) => console.log(rawData.join(',')))
-    )
-    .then((finish) => {
-      console.warn('Streaming raw data as CSV. Press any key to add a marker or escape to stop.')
+    .then(() => raw(client, rawData => console.log(rawData.join(","))))
+    .then(finish => {
+      console.warn(
+        "Streaming raw data as CSV. Press any key to add a marker or escape to stop."
+      );
       return new Promise(resolve => {
-        stdin.on('keypress', (char, key) => {
-          const time = new Date()
-          const {ctrl, alt, meta, name} = key
+        stdin.on("keypress", (char, key) => {
+          const time = new Date();
+          const { ctrl, alt, meta, name } = key;
           if (!ctrl && !alt && !meta && name.match(/^[a-z0-9]$/)) {
-            client.injectMarker({label: 'key', value: name, time})
+            client
+              .injectMarker({ label: "key", value: name, time })
               .then(() => {
-                const ftime = `${time.toLocaleTimeString()}.${time.getMilliseconds()}`
-                console.warn(`Added marker ${name} at time ${ftime}`)
-              })
-          } else if (name === 'escape' || (ctrl && name === 'c')) {
-            stdin.removeAllListeners('keypress')
-            stdin.pause()
-            resolve(finish())
+                const ftime = `${time.toLocaleTimeString()}.${time.getMilliseconds()}`;
+                console.warn(`Added marker ${name} at time ${ftime}`);
+              });
+          } else if (name === "escape" || (ctrl && name === "c")) {
+            stdin.removeAllListeners("keypress");
+            stdin.pause();
+            resolve(finish());
           }
-        })
-      })
+        });
+      });
     })
-    .close()
+    .then(() => client.close())
     .then(() => {
-      console.warn('Finished!')
-    })
+      console.warn("Finished!");
+    });
 
   // We could use the value returned by numbers) here, but when we ctrl+c it
   // will clean up the connection anyway
 }
 
-module.exports = raw
+module.exports = raw;


### PR DESCRIPTION
This PR removes the ChainablePromise from the Node.js Cortex wrapper.

This removes the ability to chain API functions back to back (i.e. `client.connect().subscribe()`), but allows the cortex wrapper to be compiled by Babel and used in projects using ES6 JS (which forbids subclassing the built-in Promise class).