### PR TITLE
COR-5662: fix bug support embedded lib on windows

### DIFF
--- a/unity/Assets/Plugins/AppConfig.cs
+++ b/unity/Assets/Plugins/AppConfig.cs
@@ -13,6 +13,8 @@ public static class AppConfig
     #if !USE_EMBEDDED_LIB && !UNITY_ANDROID && !UNITY_IOS
     // only for desktop without embedded cortex
     public static string AppUrl              = "wss://localhost:6868"; // for desktop without embedded cortex
+    #else
+    public static string AppUrl              = ""; // Don't need AppUrl for mobile and embedded cortex
     #endif
-    
+
 }

--- a/unity/Assets/SimpleExample.cs
+++ b/unity/Assets/SimpleExample.cs
@@ -137,15 +137,20 @@ public class SimpleExample : MonoBehaviour
 
     void Start()
     {
-        #if USE_EMBEDDED_LIB  && (UNITY_EDITOR_WIN || UNITY_STANDALONE_WIN)
-        // for windows and embedded lib
+    #if USE_EMBEDDED_LIB
+    #if UNITY_STANDALONE_WIN && !UNITY_EDITOR
         string[] args = Environment.GetCommandLineArgs();
         if (args.Length > 1)
         {
             _eItf.ProcessCallback(args[1]);
             return;
         }
-        #endif
+    #else
+        // Only for desktop with embedded cortex library for standalone windows
+        UnityEngine.Debug.Log("Only support embedded lib for for standalone windows.");
+        return;
+    #endif
+    #endif
 
         #if UNITY_ANDROID
             StartEmotivUnityItfForAndroid();


### PR DESCRIPTION
The PR include:
- Fix build issue after merge code unity-plugin to master. The issue because the AppUrl is not defined
- Only support embedded lib for standalone windows, do not support for editor because need to build then copy the lib to the build folder  and handle process callback. 

Please help to review. thanks