### PR TITLE
COR-5906: update .NET Framework from 4.5.2 to 4.8 across C# examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,81 @@
-*.pro.user
+### OS junk
 .DS_Store
-venv
-cortex_creds
-**__pycache__**
+Thumbs.db
+ehthumbs.db
+Icon?
+
+### General logs
+*.log
+logs/
+
+### Python
+__pycache__/
+**/__pycache__/**
+*.py[cod]
+*.pyo
+.venv/
+venv/
+.env
+.env.*
+.pytest_cache/
+.mypy_cache/
+.coverage
+
+### Node.js
+node_modules/
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+### Visual Studio /.NET
+.vs/
+[Bb]in/
+[Oo]bj/
+*.user
+*.suo
+*.userosscache
+*.sln.docstates
+TestResult*/
+*.Cache
+*.ide
+*.pdb
+*.mdb
+*.nupkg
+*.snupkg
+packages/*
+!packages/build/
+!packages/repositories.config
+csharp/packages/
+
+### Qt/C++
+*.pro.user*
+*.qmake.stash
+build-*/
+*.o
+*.obj
+*.dll
+*.lib
+*.exp
+*.ilk
+*.pdb
+Makefile*
+moc_*
+ui_*
+qrc_*
+
+### Unity
 unity/*.sln
 unity/*.csproj
 unity/Library/
 unity/Tmp/
-Temp/
+unity/Temp/
+unity/Obj/
+unity/Build/
+unity/Logs/
+unity/UserSettings/
 unity/*.userprefs
 unity/*.unityproj
+
+### Project-specific
+cortex_creds
 *build-*

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,12 @@
 # Release Notes
 
+## 30th October, 2025
+- C#: Updated all C# projects to target .NET Framework 4.8 (CortexAccess, EEGLogger, BandPowerLogger, MotionLogger, PMLogger, FacialExpressionTraining, InjectMarker, RecordData, MentalCommandTraining).
+- Updated App.config in each C# project to set `<supportedRuntime sku=".NETFramework,Version=v4.8" />` and adjusted bootstrapper metadata to .NET 4.8 where present.
+- Documentation: `csharp/README.md` now lists .NET Framework 4.8 (or newer) as the requirement.
+- Repo hygiene: Expanded top-level `.gitignore` to exclude common build artifacts and caches for Visual Studio/.NET, Unity, Node.js, Python, Qt/Qt Creator, and OS junk files.
+- Compatibility note: No code-level breaking changes are expected with the move to .NET 4.8. Developer machines should have the .NET Framework 4.8 Developer Pack to build; target machines require the .NET Framework 4.8 runtime. Cortex service continues to require TLS 1.2+; ensure the Emotiv root CA is trusted locally if you encounter TLS trust issues on `wss://localhost:6868`.
+
 ## 30th November, 2022
 - Add Emotiv's self-signed certificate rootCA.pem
 - Update python example to use the Emotiv's self-signed certificate when open a secure Websocket connection to Emotiv Cortex Websocket

--- a/csharp/BandPowerLogger/App.config
+++ b/csharp/BandPowerLogger/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/csharp/BandPowerLogger/BandPowerLogger.csproj
+++ b/csharp/BandPowerLogger/BandPowerLogger.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BandPowerLogger</RootNamespace>
     <AssemblyName>BandPowerLogger</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/csharp/CortexAccess/App.config
+++ b/csharp/CortexAccess/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/csharp/CortexAccess/CortexAccess.csproj
+++ b/csharp/CortexAccess/CortexAccess.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>CortexAccess</RootNamespace>
     <AssemblyName>CortexAccess</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PublishUrl>publish\</PublishUrl>
@@ -92,9 +92,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 and x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.8 %28x86 and x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">

--- a/csharp/EEGLogger/App.config
+++ b/csharp/EEGLogger/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/csharp/EEGLogger/EEGLogger.csproj
+++ b/csharp/EEGLogger/EEGLogger.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EEGLogger</RootNamespace>
     <AssemblyName>EEGLogger</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/csharp/FacialExpressionTraining/App.config
+++ b/csharp/FacialExpressionTraining/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
 </configuration>

--- a/csharp/FacialExpressionTraining/FacialExpressionTraining.csproj
+++ b/csharp/FacialExpressionTraining/FacialExpressionTraining.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>FacialExpressionTraining</RootNamespace>
     <AssemblyName>FacialExpressionTraining</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/csharp/InjectMarker/App.config
+++ b/csharp/InjectMarker/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
 </configuration>

--- a/csharp/InjectMarker/InjectMarkers.csproj
+++ b/csharp/InjectMarker/InjectMarkers.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>InjectMarker</RootNamespace>
     <AssemblyName>InjectMarker</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/csharp/MentalCommandTraining/MentalCommandTraining.csproj
+++ b/csharp/MentalCommandTraining/MentalCommandTraining.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MentalCommandTraining</RootNamespace>
     <AssemblyName>MentalCommandTraining</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/csharp/MotionLogger/App.config
+++ b/csharp/MotionLogger/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/csharp/MotionLogger/MotionLogger.csproj
+++ b/csharp/MotionLogger/MotionLogger.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MotionLogger</RootNamespace>
     <AssemblyName>MotionLogger</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/csharp/PMLogger/App.config
+++ b/csharp/PMLogger/App.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+  <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">

--- a/csharp/PMLogger/PMLogger.csproj
+++ b/csharp/PMLogger/PMLogger.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>PMLogger</RootNamespace>
     <AssemblyName>PMLogger</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <PublishUrl>publish\</PublishUrl>
@@ -79,9 +79,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <BootstrapperPackage Include=".NETFramework,Version=v4.5.2">
+    <BootstrapperPackage Include=".NETFramework,Version=v4.8">
       <Visible>False</Visible>
-      <ProductName>Microsoft .NET Framework 4.5.2 %28x86 and x64%29</ProductName>
+      <ProductName>Microsoft .NET Framework 4.8 %28x86 and x64%29</ProductName>
       <Install>true</Install>
     </BootstrapperPackage>
     <BootstrapperPackage Include="Microsoft.Net.Framework.3.5.SP1">

--- a/csharp/README.md
+++ b/csharp/README.md
@@ -7,7 +7,7 @@ This repository provides C# console applications that demonstrate how to use the
 
 ### Requirements
 - **Visual Studio 2019 or newer** (Community/Professional/Enterprise)
-- **.NET Framework 4.7.2 or newer**
+- **.NET Framework 4.8 or newer**
 - **C# compiler**: Use the default provided by Visual Studio
 - **NuGet Packages** (install via NuGet Package Manager):
   - `Newtonsoft.Json`

--- a/csharp/RecordData/App.config
+++ b/csharp/RecordData/App.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
     </startup>
 </configuration>

--- a/csharp/RecordData/RecordData.csproj
+++ b/csharp/RecordData/RecordData.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>RecordData</RootNamespace>
     <AssemblyName>RecordData</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+  <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>


### PR DESCRIPTION
This PR upgrades all C# projects to target .NET Framework 4.8.
Changes

Update <TargetFrameworkVersion>v4.8</TargetFrameworkVersion> for all example projects (CortexAccess, EEGLogger, BandPowerLogger, MotionLogger, PMLogger, FacialExpressionTraining, InjectMarker, RecordData, MentalCommandTraining)
Align [App.config](vscode-file://vscode-app/c:/Users/girem/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) <supportedRuntime sku=".NETFramework,Version=v4.8" />
Update bootstrapper metadata where present
Expand repo-wide .gitignore for Visual Studio/.NET, Unity, Node.js, Python, Qt, and OS artifacts
Docs: [README.md](vscode-file://vscode-app/c:/Users/girem/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) now lists .NET Framework 4.8+
Release notes: add 2025-10-30 entry with compatibility notes